### PR TITLE
Support width and compression parameters in MediaPlugin

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -16,6 +16,7 @@ export interface MediaPlugin {
   getMediaByIdentifier(options?: {
     identifier: string;
     width?: number;
+    compression?: number;
   }): Promise<MediaPath>;
   /**
    * Get list of albums.


### PR DESCRIPTION
Introduce support for specifying width and compression parameters when fetching media. Validate the compression value to ensure it falls within an acceptable range.